### PR TITLE
display annotation content text by filtering for annotation purpose

### DIFF
--- a/src/components/Annotations/Annotations.tsx
+++ b/src/components/Annotations/Annotations.tsx
@@ -4,16 +4,18 @@ interface AnnotationsProps {
     annotations: Array<Object>;
 }
 
-class Annotations extends React.Component <AnnotationsProps> {
+class Annotations extends React.Component<AnnotationsProps> {
     render() {
         const annotation: Array<Object> = []
         for (const annoData of this.props.annotations) {
-          const selector = annoData["target"]["selector"].filter((s) => s["type"] === "TextQuoteSelector")[0]
-          annotation.push(<div key={annoData["id"]} style={{lineHeight: '1.5em',
-              display: 'block', color: 'darkslategray', marginTop: '2em'}}>
-              <blockquote>"...{selector.prefix} <span style={{color: '#3F3730', fontWeight: 'bolder'}}>{selector.exact}</span> {selector.suffix}..."</blockquote>
-              <span style={{fontStyle: "italic"}}>{annoData["body"][0]["value"]}</span>
-          </div>)
+            const selector = annoData["target"]["selector"].filter((s) => s["type"] === "TextQuoteSelector")[0]
+            annotation.push(<div key={annoData["id"]} style={{
+                lineHeight: '1.5em',
+                display: 'block', color: 'darkslategray', marginTop: '2em'
+            }}>
+                <blockquote>"...{selector.prefix} <span style={{ color: '#3F3730', fontWeight: 'bolder' }}>{selector.exact}</span> {selector.suffix}..."</blockquote>
+                <span style={{ fontStyle: "italic" }}>{annoData["body"].filter((a) => a["purpose"] === "commenting")[0]["value"]}</span>
+            </div>)
         }
         return <>{annotation}</>
     }


### PR DESCRIPTION
This modifies the Annotations component to correctly pull the `body` object from an annotation that is the "commenting" text. The other potential objects in the `body` list are `"purpose": "tagging"` objects, which are the tags. Ideally, we still need to be able to display the list of tags for an annotation under the commenting text, but just getting the commenting text to show up is the main priority.